### PR TITLE
Chore: Default path_prefix to the repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ steps:
 | Variable Name | Required | Default | Description                                    |
 | ------------- | -------- | ------- | ---------------------------------------------- |
 | exit_on_fail  | False    | True    | Action will exit with an error on mismatch     |
-| path_prefix   | False    | None    | Directory path to the repository/project files |
+| path_prefix   | False    | .       | Directory path to the repository/project files |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,7 @@ inputs:
   path_prefix:
     description: 'Directory location containing project code'
     required: false
+    default: '.'
   # For testing purposes ONLY, do not use
   test_tag:
     description: 'Undocumented test input/value'


### PR DESCRIPTION
## Chore: Default `path_prefix` to the repository root

Every sibling action in this organisation declares `path_prefix` with a `.` default — 28 of them. This one omitted it, so the declared interface didn't state where the action looks by default, and callers had to infer it.

## Behaviour is unchanged

This action forwards `path_prefix` straight through to `python-project-version-action`:

```yaml
- uses: lfreleng-actions/python-project-version-action@…
  with:
    path_prefix: "${{ inputs.path_prefix }}"
```

That action declares its own `.` default — but passing an explicit empty string **overrides** it rather than falling back to it. Declaring `.` here means the forwarded value now matches the downstream default instead of blanking it, which is what callers already expect.

The practical gain is also that GitHub surfaces the default in the Actions UI and in generated documentation, rather than leaving it blank.

## Context

Part of a small consistency sweep across the estate, alongside [`gradle-build-action#103`](https://github.com/lfreleng-actions/gradle-build-action/pull/103), which aligns that action's outlier `path` input onto `path_prefix`.

Deliberately **not** included in the sweep: `python-audit-action`, which defaults `path_prefix` to `''`. That empty default is load-bearing — it is passed to `pypa/gh-action-pip-audit` as `inputs:`, where empty means *"audit the installed environment"* while `'.'` would mean *"scan this directory"*. Changing it there would alter what gets audited.

## Validation

`pre-commit run --all-files` — all hooks pass.